### PR TITLE
Fix string array length comparison causing index out of bound panic in index.go hasPrefix()

### DIFF
--- a/index.go
+++ b/index.go
@@ -75,7 +75,7 @@ func (o *IndexDef) changeColumn(originalName, newName string) {
 }
 
 func (o *IndexDef) hasPrefix(columns []string) bool {
-	if len(o.Columns) < len(columns) {
+	if len(o.Columns) > len(columns) {
 		return false
 	}
 


### PR DESCRIPTION
Reported by issue https://github.com/bytewatch/ddl-executor/issues/1